### PR TITLE
Change HPE pubkey url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 yum-HP Cookbook CHANGELOG
 ======================
+v0.0.3 (2017-08-24)
+------
+Changed public key url
+
 v0.0.2 (2015-07-25)
 ------
 Changed hp-spp repo baseurl

--- a/attributes/hp-spp.rb
+++ b/attributes/hp-spp.rb
@@ -1,6 +1,6 @@
 default['yum']['hp-spp']['repositoryid'] = 'hp-spp'
 
-default['yum']['hp-spp']['gpgkey'] = 'http://downloads.linux.hpe.com/SDR/hpPublicKey2048_key1.pub'
+default['yum']['hp-spp']['gpgkey'] = 'http://downloads.linux.hpe.com/SDR/hpePublicKey2048_key1.pub'
 
 case node['platform_version'].to_i
 when 6

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,4 +7,4 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 depends 'yum', '~> 3.2'
 supports 'centos'
 
-version '0.0.2'
+version '0.0.3'


### PR DESCRIPTION
HPE uses new key to sign packages thus producing errors like 

```
warning: /var/cache/yum/x86_64/7/hp-spp/packages/mlnx-ofa_kernel-3.4-OFED.3.4.2.1.5.1.ged26eb5.1.rhel7u3.x86_64.rpm: Header V3 RSA/SHA256 Signature, key ID 26c2b797: NOKEY

The GPG keys listed for the "HP Service Pack Packages for Enterprise Linux 7 - x86_64" repository are already installed but they are not correct for this package.
Check that the correct key URLs are configured for this repository.
```

@benner 