### PR TITLE
Fix yum_repository deprecation warnings, verify all packages

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,11 +6,33 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: centos-6.7
-  - name: centos-7.1
+  - name: centos-6.10
+  - name: centos-7.7
+
+verifier:
+  name: inspec
+  inspec_tests:
+    - path: test/integration/default
 
 suites:
-  - name: default
+  - name: default-12
+    provisioner:
+      product_name: chef
+      product_version: 12
+    run_list:
+      - recipe[yum-hp::default]
+      - recipe[yum-hp-test::default]
+  - name: default-13
+    provisioner:
+      product_name: chef
+      product_version: 13
+    run_list:
+      - recipe[yum-hp::default]
+      - recipe[yum-hp-test::default]
+  - name: default-14
+    provisioner:
+      product_name: chef
+      product_version: 14
     run_list:
       - recipe[yum-hp::default]
       - recipe[yum-hp-test::default]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 yum-HP Cookbook CHANGELOG
 ======================
+v0.0.4 (2019-10-21)
+------
+Import all HPE public keys to verify all package versions, recommended by https://downloads.linux.hpe.com/SDR/keys.html
+Get rid of yum cookbook dependency and require chef-client 12.14+
+Test with Chef12, Chef13 and Chef14, verify via InSpec
+
 v0.0.3 (2017-08-24)
 ------
 Changed public key url

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ The yum-hp cookbook install HP SPP YUM repo
 
 Requirements
 ------------
-* Chef 12 or higher
-* yum cookbook version 3.2.0 or higher
+* Chef 12.14 or higher
 
 Attributes
 ----------

--- a/attributes/hp-spp.rb
+++ b/attributes/hp-spp.rb
@@ -1,6 +1,11 @@
 default['yum']['hp-spp']['repositoryid'] = 'hp-spp'
 
-default['yum']['hp-spp']['gpgkey'] = 'http://downloads.linux.hpe.com/SDR/hpePublicKey2048_key1.pub'
+default['yum']['hp-spp']['gpgkey'] = [
+  'https://downloads.linux.hpe.com/SDR/hpPublicKey1024.pub',
+  'https://downloads.linux.hpe.com/SDR/hpPublicKey2048.pub',
+  'https://downloads.linux.hpe.com/SDR/hpPublicKey2048_key1.pub',
+  'https://downloads.linux.hpe.com/SDR/hpePublicKey2048_key1.pub'
+]
 
 case node['platform_version'].to_i
 when 6

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,4 +9,4 @@ chef_version '>= 12.14'
 
 supports 'centos'
 
-version '0.0.3'
+version '0.0.4'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,9 @@ maintainer_email 'nerijus.bendziunas@gmail.com'
 license 'Apache 2.0'
 description 'Installs/Configures HP Service Pack for ProLiant YUM repository'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-depends 'yum', '~> 3.2'
+
+chef_version '>= 12.14'
+
 supports 'centos'
 
 version '0.0.3'

--- a/test/integration/default/bats/hp-ssp_installed_and_works.bats
+++ b/test/integration/default/bats/hp-ssp_installed_and_works.bats
@@ -1,7 +1,0 @@
-#!/usr/bin/env bats
-
-@test "HP SPP - hpssacli package is installed" {
-  run rpm -q hpssacli
-  [ "$status" -eq 0 ]
-}
-

--- a/test/integration/default/inspec_default.rb
+++ b/test/integration/default/inspec_default.rb
@@ -1,0 +1,8 @@
+describe yum.repo('hp-spp') do
+  it { should exist }
+  it { should be_enabled }
+end
+
+describe package('hpssacli') do
+  it { should be_installed }
+end


### PR DESCRIPTION
* Get rid of yum cookbook dependency and require chef-client 12.14+
* Test with Chef12, Chef13 and Chef14, verify via InSpec

* Import all HPE public keys to verify all package versions, recommended by https://downloads.linux.hpe.com/SDR/keys.html

@benner 